### PR TITLE
Fix disable method bug with the repeatable option.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Release history
 
+## vNext
+
+### Repeat after me: I will stop when asked to
+With the `isRepeatable` option activated, the previous flow allowed to disable the button in between repeats. The
+button would be disabled but would keep on emitting the `tap` event.
+
 ## v0.1.3
 
 ### I care about you deeply

--- a/index.js
+++ b/index.js
@@ -238,15 +238,15 @@ function buttonBehavior(button, options) {
 	button.on('tapstart', function () {
 		if (isRepeatable) {
 			// We do an initial tap and then wait for the initial delay.
-			button.emit('tap');
 			repeatableTimeout = window.setTimeout(repeatTap, repeatableInitialDelay);
+			button.emit('tap');
 		}
 	});
 
 	function repeatTap() {
 		// Send another tap and wait for the shorter delay.
-		button.emit('tap');
 		repeatableTimeout = window.setTimeout(repeatTap, repeatableDelay);
+		button.emit('tap');
 	}
 
 	button.on('tapend', function (wasCancelled) {


### PR DESCRIPTION
Emit the tap event last to have a updated value in the repeatableTimeout var that we try to clear.
